### PR TITLE
Add reminder by email for Task

### DIFF
--- a/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/TaskAddOrEdit.tsx
+++ b/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/TaskAddOrEdit.tsx
@@ -9,6 +9,7 @@ import ComponentSelectWorkspace from './ComponentSelectWorkspace';
 import ComponentSelectTaskStatus from './ComponentSelectTaskStatus';
 
 import getDateTimeForInputTypeDateTimeLocal from '../../../../../utils/getDateTimeForInputTypeDateTimeLocal';
+import { reminderLabelToMsArr } from './taskEditCons';
 
 const TaskAddOrEdit: React.FC<{
     isTaskAddModalIsOpen: {
@@ -30,6 +31,9 @@ const TaskAddOrEdit: React.FC<{
     const [labels, setLabels] = useState<string[]>([]); // New state for labels
     const [newLabel, setNewLabel] = useState(''); // New state for new label
     const [isAddingLabel, setIsAddingLabel] = useState(false); // State to control label input visibility
+
+    // remainder
+    const [reminderPresetTimeLabel, setReminderPresetTimeLabel] = useState('before-1-day');
 
     const [formData, setFormData] = useState({
         priority: '',
@@ -86,6 +90,8 @@ const TaskAddOrEdit: React.FC<{
                             isCompleted: taskInfo.isCompleted || false,
                             priority: taskInfo.priority || '',
                         });
+
+                        setReminderPresetTimeLabel(taskInfo.reminderPresetTimeLabel || 'before-1-day');
                     } else {
                         toggleModal();
                     }
@@ -101,6 +107,7 @@ const TaskAddOrEdit: React.FC<{
                 setLabels([]); // Reset labels
                 setNewLabel(''); // Reset new label
                 setIsAddingLabel(false); // Reset label input visibility
+                setReminderPresetTimeLabel('before-1-day');
             }
         };
 
@@ -141,6 +148,9 @@ const TaskAddOrEdit: React.FC<{
             // workspace
             taskWorkspaceId: workspaceId,
             taskStatusId: taskStatusId,
+
+            // remainder
+            reminderPresetTimeLabel: reminderPresetTimeLabel,
         } as {
             id?: string;
             title: string;
@@ -161,6 +171,9 @@ const TaskAddOrEdit: React.FC<{
             // workspace
             taskWorkspaceId: string;
             taskStatusId: string;
+
+            // remainder
+            reminderPresetTimeLabel: string;
         };
 
         if (isTaskAddModalIsOpen.modalType === 'edit') {
@@ -185,7 +198,7 @@ const TaskAddOrEdit: React.FC<{
             setStatus('todo'); // Reset status
             setDueDate(''); // Reset due date
             setLabels([]); // Reset labels
-
+            setReminderPresetTimeLabel('before-1-day');
             if (isTaskAddModalIsOpen.modalType === 'add') {
                 // Redirect to task list with workspace parameter
                 window.location.href = `/user/task?workspace=${workspaceId}`;
@@ -493,6 +506,24 @@ const TaskAddOrEdit: React.FC<{
                                                 </button>
                                             )}
                                         </div>
+
+                                        {/* reminder preset time label */}
+                                        {
+                                            dueDate && (
+                                                <div className="py-2 flex items-center gap-2 bg-gray-100 rounded-lg p-2">
+                                                    <label className="block font-medium">Reminder Preset Time Label:</label>
+                                                    <select
+                                                        className="border border-gray-300 rounded-lg p-1 focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-200"
+                                                        value={reminderPresetTimeLabel}
+                                                        onChange={(e) => setReminderPresetTimeLabel(e.target.value)}
+                                                    >
+                                                        {reminderLabelToMsArr.map((label) => (
+                                                            <option key={label.labelName} value={label.labelName}>{label.labelNameStr}</option>
+                                                        ))}
+                                                    </select>
+                                                </div>
+                                            )
+                                        }
                                     </div>
 
                                     {isAddingLabel && (

--- a/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/TaskAddOrEdit.tsx
+++ b/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/TaskAddOrEdit.tsx
@@ -511,7 +511,7 @@ const TaskAddOrEdit: React.FC<{
                                         {
                                             dueDate && (
                                                 <div className="py-2 flex items-center gap-2 bg-gray-100 rounded-lg p-2">
-                                                    <label className="block font-medium">Reminder Preset Time Label:</label>
+                                                    <label className="block font-medium">Reminder:</label>
                                                     <select
                                                         className="border border-gray-300 rounded-lg p-1 focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-200"
                                                         value={reminderPresetTimeLabel}

--- a/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/taskEditCons.ts
+++ b/src/pages/user/noteAdvance/taskList/ComponentTaskEdit/taskEditCons.ts
@@ -1,0 +1,70 @@
+// Simple calculation of reminder times based on dueDate and preset labels (lowercase, minus)
+
+interface IReminderLabelToMsArr {
+    labelName: string;
+    labelNameStr: string;
+    subTime: number;
+}
+
+export const reminderLabelToMsArr: IReminderLabelToMsArr[] = [
+    {
+        labelName: "before-60-day",
+        labelNameStr: "60 days before",
+        subTime: 60 * 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-30-day",
+        labelNameStr: "30 days before",
+        subTime: 30 * 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-15-day",
+        labelNameStr: "15 days before",
+        subTime: 15 * 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-5-day",
+        labelNameStr: "5 days before",
+        subTime: 5 * 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-3-day",
+        labelNameStr: "3 days before",
+        subTime: 3 * 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-1-day",
+        labelNameStr: "1 day before",
+        subTime: 24 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-6-hours",
+        labelNameStr: "6 hours before",
+        subTime: 6 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-3-hours",
+        labelNameStr: "3 hours before",
+        subTime: 3 * 60 * 60 * 1000
+    },
+    {
+        labelName: "before-1-hours",
+        labelNameStr: "1 hour before",
+        subTime: 60 * 60 * 1000
+    },
+    {
+        labelName: "before-30-mins",
+        labelNameStr: "30 minutes before",
+        subTime: 30 * 60 * 1000
+    },
+    {
+        labelName: "before-15-mins",
+        labelNameStr: "15 minutes before",
+        subTime: 15 * 60 * 1000
+    },
+    {
+        labelName: "at-the-time-of-due-date",
+        labelNameStr: "At the time of due date",
+        subTime: 0
+    },
+];


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a due-date–dependent reminder preset selector and persists `reminderPresetTimeLabel` in task add/edit payloads.
> 
> - **Task Edit UI (`TaskAddOrEdit.tsx`)**:
>   - Adds reminder state `reminderPresetTimeLabel` (default `before-1-day`), initializes from `taskInfo`, resets on clear/submit.
>   - Persists `reminderPresetTimeLabel` in add/edit request payloads.
>   - Renders a reminder preset `<select>` only when `dueDate` is set, populated from `reminderLabelToMsArr`.
> - **Constants (`taskEditCons.ts`)**:
>   - New file exporting `reminderLabelToMsArr` (preset labels and offsets) used by the UI.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79581e70b777c811f5f6dc9e10c8ac2135062d88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->